### PR TITLE
音楽アルバムのデータを取得する処理とページ作成処理を実装

### DIFF
--- a/Experience2Notion/Configs/Consts.cs
+++ b/Experience2Notion/Configs/Consts.cs
@@ -6,4 +6,5 @@ public static class Consts
     public const string GenreKey = "ジャンル";
 
     public const string BookIconUrl = "https://www.notion.so/icons/book-closed_red.svg";
+    public const string MusicIconUrl = "https://www.notion.so/icons/music-album_pink.svg";
 }

--- a/Experience2Notion/Models/Spotifies/Album.cs
+++ b/Experience2Notion/Models/Spotifies/Album.cs
@@ -1,14 +1,21 @@
-﻿namespace Experience2Notion.Models.Spotifies;
+﻿using System.Text.Json.Serialization;
+
+namespace Experience2Notion.Models.Spotifies;
 public class Album
 {
+    [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
 
+    [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
+    [JsonPropertyName("images")]
     public List<Image> Images { get; set; } = [];
 
+    [JsonPropertyName("artists")]
     public List<Artist> Artists { get; set; } = [];
 
+    [JsonPropertyName("release_date")]
     public string ReleaseDate { get; set; } = string.Empty;
 
     public string ExternalUrl => $"https://open.spotify.com/album/{Id}";

--- a/Experience2Notion/Models/Spotifies/Album.cs
+++ b/Experience2Notion/Models/Spotifies/Album.cs
@@ -1,0 +1,15 @@
+﻿namespace Experience2Notion.Models.Spotifies;
+public class Album
+{
+    public string Id { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+
+    public List<Image> Images { get; set; } = [];
+
+    public List<Artist> Artists { get; set; } = [];
+
+    public string ReleaseDate { get; set; } = string.Empty;
+
+    public string ExternalUrl => $"https://open.spotify.com/album/{Id}";
+}

--- a/Experience2Notion/Models/Spotifies/Artist.cs
+++ b/Experience2Notion/Models/Spotifies/Artist.cs
@@ -1,0 +1,5 @@
+﻿namespace Experience2Notion.Models.Spotifies;
+public class Artist
+{
+    public string Name { get; set; } = string.Empty;
+}

--- a/Experience2Notion/Models/Spotifies/Artist.cs
+++ b/Experience2Notion/Models/Spotifies/Artist.cs
@@ -1,5 +1,8 @@
-﻿namespace Experience2Notion.Models.Spotifies;
+﻿using System.Text.Json.Serialization;
+
+namespace Experience2Notion.Models.Spotifies;
 public class Artist
 {
+    [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 }

--- a/Experience2Notion/Models/Spotifies/Image.cs
+++ b/Experience2Notion/Models/Spotifies/Image.cs
@@ -1,15 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text.Json.Serialization;
 
 namespace Experience2Notion.Models.Spotifies;
 public class Image
 {
+    [JsonPropertyName("url")]
     public string Url { get; set; } = string.Empty;
 
+    [JsonPropertyName("height")]
     public int Height { get; set; }
 
+    [JsonPropertyName("width")]
     public int Width { get; set; }
 }

--- a/Experience2Notion/Models/Spotifies/Image.cs
+++ b/Experience2Notion/Models/Spotifies/Image.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Experience2Notion.Models.Spotifies;
+public class Image
+{
+    public string Url { get; set; } = string.Empty;
+
+    public int Height { get; set; }
+
+    public int Width { get; set; }
+}

--- a/Experience2Notion/Models/Spotifies/SpotifySearchResponse.cs
+++ b/Experience2Notion/Models/Spotifies/SpotifySearchResponse.cs
@@ -1,10 +1,14 @@
-﻿namespace Experience2Notion.Models.Spotifies;
+﻿using System.Text.Json.Serialization;
+
+namespace Experience2Notion.Models.Spotifies;
 public class SpotifySearchResponse
 {
+    [JsonPropertyName("albums")]
     public SpotifyAlbumContainer Albums { get; set; } = new();
 }
 
 public class SpotifyAlbumContainer
 {
+    [JsonPropertyName("items")]
     public List<Album> Items { get; set; } = [];
 }

--- a/Experience2Notion/Models/Spotifies/SpotifySearchResponse.cs
+++ b/Experience2Notion/Models/Spotifies/SpotifySearchResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace Experience2Notion.Models.Spotifies;
+public class SpotifySearchResponse
+{
+    public SpotifyAlbumContainer Albums { get; set; } = new();
+}
+
+public class SpotifyAlbumContainer
+{
+    public List<Album> Items { get; set; } = [];
+}

--- a/Experience2Notion/Services/NotionClient.cs
+++ b/Experience2Notion/Services/NotionClient.cs
@@ -58,9 +58,52 @@ public partial class NotionClient
 
     public async Task<CreatePageResponse> CreateBookPageAsync(string title, IList<string> authors, string link, string publishedDate, string imageId)
     {
-        _logger.LogInformation($"Notionにページを作成します。");
-        var bookGenre = _genres.First(g => g.Name == "書籍");
+        _logger.LogInformation($"Notionに書籍ページを作成します。");
+        var payload = CreateNotionPagePayload(title, "書籍", [.. authors], link, publishedDate, imageId);
+        var jsonPayload = JsonSerializer.Serialize(payload);
+        var content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json);
+        var response = await _client.PostAsync(_createPagesUrl, content);
+        response.EnsureSuccessStatusCode();
+        _logger.LogInformation($"Notionのページを作成しました。");
+        _logger.LogInformation("タイトル: {Title}", title);
+        _logger.LogInformation("著者: {Authors}", string.Join(", ", authors));
+        _logger.LogInformation("リンク: {Link}", link);
+        if (DatetimeRegex().IsMatch(publishedDate))
+        {
+            _logger.LogInformation("発売日: {PublishedDate}", publishedDate);
+        }
+        var jsonRes = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<CreatePageResponse>(jsonRes)!;
+    }
+
+    public async Task<CreatePageResponse> CreateMusicAlbumPageAsync(string title, string artist, string link, string releaseDate, string imageId)
+    {
+        _logger.LogInformation($"Notionに音楽アルバムページを作成します。");
+        var payload = CreateNotionPagePayload(title, "音楽アルバム", [artist], link, releaseDate, imageId);
+        var jsonPayload = JsonSerializer.Serialize(payload);
+        var content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json);
+        var response = await _client.PostAsync(_createPagesUrl, content);
+        response.EnsureSuccessStatusCode();
+        _logger.LogInformation($"Notionのページを作成しました。");
+        _logger.LogInformation("タイトル: {Title}", title);
+        _logger.LogInformation("アーティスト {Artist}", artist);
+        _logger.LogInformation("リンク: {Link}", link);
+        _logger.LogInformation("発売日: {ReleaseDate}", releaseDate);
+        var jsonRes = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<CreatePageResponse>(jsonRes)!;
+    }
+
+    private NotionPageCreate CreateNotionPagePayload(string title, string genre, string[] authors, string link, string publishedDate, string imageId)
+    {
+        var genreOption = _genres.First(g => g.Name == genre);
+        var IconUrl = genre switch
+        {
+            "書籍" => Consts.BookIconUrl,
+            "音楽アルバム" => Consts.MusicIconUrl,
+            _ => ""
+        };
         var authorOptions = authors.Select(author => _authors.FirstOrDefault(a => a.Name == author) ?? new SelectOption { Name = author }).ToList();
+
         var payload = new NotionPageCreate
         {
             Parent = new Parent { DatabaseId = _databaseId },
@@ -69,7 +112,7 @@ public partial class NotionClient
                 Type = "external",
                 External = new ExternalFile
                 {
-                    Url = Consts.BookIconUrl
+                    Url = IconUrl
                 }
             },
             Properties = new PageProperties
@@ -97,7 +140,7 @@ public partial class NotionClient
                 },
                 Genre = new SelectValueByPage
                 {
-                    Select = bookGenre
+                    Select = genreOption
                 },
             },
             Children =
@@ -129,103 +172,7 @@ public partial class NotionClient
                 }
             };
         }
-        var jsonPayload = JsonSerializer.Serialize(payload);
-        var content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json);
-        var response = await _client.PostAsync(_createPagesUrl, content);
-        response.EnsureSuccessStatusCode();
-        _logger.LogInformation($"Notionのページを作成しました。");
-        _logger.LogInformation("タイトル: {Title}", title);
-        _logger.LogInformation("著者: {Authors}", string.Join(", ", authors));
-        _logger.LogInformation("リンク: {Link}", link);
-        if (DatetimeRegex().IsMatch(publishedDate))
-        {
-            _logger.LogInformation("発売日: {PublishedDate}", publishedDate);
-        }
-        var jsonRes = await response.Content.ReadAsStringAsync();
-        return JsonSerializer.Deserialize<CreatePageResponse>(jsonRes)!;
-    }
-
-    public async Task<CreatePageResponse> CreateMusicAlbumPageAsync(string title, string artist, string link, string releaseDate, string imageId)
-    {
-        _logger.LogInformation($"Notionにページを作成します。");
-        var genre = _genres.First(g => g.Name == "音楽アルバム");
-        var authorOptions = _authors.FirstOrDefault(a => a.Name == artist) ?? new SelectOption { Name = artist };
-        var payload = new NotionPageCreate
-        {
-            Parent = new Parent { DatabaseId = _databaseId },
-            Icon = new Icon
-            {
-                Type = "external",
-                External = new ExternalFile
-                {
-                    Url = Consts.MusicIconUrl
-                }
-            },
-            Properties = new PageProperties
-            {
-                Title = new TitleProperty
-                {
-                    Title = [
-                        new TextObject
-                        {
-                            Text = new TextContent { Content = title }
-                        }
-                    ]
-                },
-                Authors = new MultiSelectValueByPage
-                {
-                    MultiSelect = [authorOptions]
-                },
-                Link = new UrlValueByPage
-                {
-                    Url = link
-                },
-                Status = new StatusValueByPage
-                {
-                    Status = _notStartStatus
-                },
-                Genre = new SelectValueByPage
-                {
-                    Select = genre
-                },
-                PublishedDate = new DateValueByPage
-                {
-                    Date = new DateValue
-                    {
-                        Start = releaseDate
-                    }
-                }
-            },
-            Children =
-            [
-                new ParagraphBlock {
-                    Paragraph = new ParagraphContent{
-                        RichText = []
-                    }
-                },
-                new ImageBlock
-                {
-                    Image = new ImageContent
-                    {
-                        Type = "file_upload",
-                        FileUpload = new FileUploadContent{
-                            Id = imageId
-                        }
-                    }
-                }
-            ]
-        };
-        var jsonPayload = JsonSerializer.Serialize(payload);
-        var content = new StringContent(jsonPayload, Encoding.UTF8, MediaTypeNames.Application.Json);
-        var response = await _client.PostAsync(_createPagesUrl, content);
-        response.EnsureSuccessStatusCode();
-        _logger.LogInformation($"Notionのページを作成しました。");
-        _logger.LogInformation("タイトル: {Title}", title);
-        _logger.LogInformation("アーティスト {Artist}", artist);
-        _logger.LogInformation("リンク: {Link}", link);
-        _logger.LogInformation("発売日: {ReleaseDate}", releaseDate);
-        var jsonRes = await response.Content.ReadAsStringAsync();
-        return JsonSerializer.Deserialize<CreatePageResponse>(jsonRes)!;
+        return payload;
     }
 
     private void LoadProperties()

--- a/Experience2Notion/Services/SpotifyClient.cs
+++ b/Experience2Notion/Services/SpotifyClient.cs
@@ -1,14 +1,9 @@
 ﻿using Experience2Notion.Models.Spotifies;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http.Headers;
-using System.Net.Http;
+using System.Net.Mime;
 using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
-using System.Net.Mime;
 
 namespace Experience2Notion.Services;
 public class SpotifyClient
@@ -46,7 +41,7 @@ public class SpotifyClient
         return json.RootElement.GetProperty("access_token").GetString()!;
     }
 
-    public async Task<SpotifyAlbum?> SearchAlbumAsync(string albumName, string artist)
+    public async Task<Album?> SearchAlbumAsync(string albumName, string artist)
     {
         var url = $"https://api.spotify.com/v1/search?q=album:{Uri.EscapeDataString(albumName)}%20artist:{Uri.EscapeDataString(artist)}&type=album&limit=1";
         var response = await _client.GetAsync(url);

--- a/Experience2Notion/Services/SpotifyClient.cs
+++ b/Experience2Notion/Services/SpotifyClient.cs
@@ -1,0 +1,60 @@
+﻿using Experience2Notion.Models.Spotifies;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Net.Mime;
+
+namespace Experience2Notion.Services;
+public class SpotifyClient
+{
+    private readonly ILogger<SpotifyClient> _logger;
+    private readonly HttpClient _client = new HttpClient();
+
+    public SpotifyClient(ILogger<SpotifyClient> logger)
+    {
+        _logger = logger;
+
+        var clientId = Environment.GetEnvironmentVariable("SPOTIFY_CLIENT_ID");
+        var clientSecret = Environment.GetEnvironmentVariable("SPOTIFY_CLIENT_SECRET");
+        Task.Run(async () =>
+        {
+            var token = await GetAccessTokenAsync(clientId!, clientSecret!);
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }).GetAwaiter().GetResult();
+    }
+
+    private async Task<string> GetAccessTokenAsync(string clientId, string clientSecret)
+    {
+        var authHeader = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{clientId}:{clientSecret}"));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "https://accounts.spotify.com/api/token");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", authHeader);
+        request.Content = new StringContent("grant_type=client_credentials", Encoding.UTF8, MediaTypeNames.Application.FormUrlEncoded);
+
+        var response = await _client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+
+        using var stream = await response.Content.ReadAsStreamAsync();
+        var json = await JsonDocument.ParseAsync(stream);
+
+        return json.RootElement.GetProperty("access_token").GetString()!;
+    }
+
+    public async Task<SpotifyAlbum?> SearchAlbumAsync(string albumName, string artist)
+    {
+        var url = $"https://api.spotify.com/v1/search?q=album:{Uri.EscapeDataString(albumName)}%20artist:{Uri.EscapeDataString(artist)}&type=album&limit=1";
+        var response = await _client.GetAsync(url);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync();
+        var data = JsonSerializer.Deserialize<SpotifySearchResponse>(json);
+
+        return data?.Albums.Items.FirstOrDefault();
+    }
+}


### PR DESCRIPTION
## 対応issue
close #10 

## 実装内容
- Spotify APIからデータを取得するSpotifyClientクラスを実装
- NotionClientに音楽アルバムページを作成する`CreateMusicAlbumPageAsync`を実装

## テスト内容
- [ ] a

## やらないこと/他issueでやること
- 

## その他レビュアーに伝えたいこと
- 
