### PR TITLE
書籍表紙画像をOpen Library Covers API優先で取得する

### DIFF
--- a/Experience2Notion/Services/BookCoverClient.cs
+++ b/Experience2Notion/Services/BookCoverClient.cs
@@ -1,0 +1,93 @@
+using Experience2Notion.Exceptions;
+using Google.Apis.Books.v1.Data;
+using Microsoft.Extensions.Logging;
+using System.Net;
+
+namespace Experience2Notion.Services;
+
+public class BookCoverClient(ILogger<BookCoverClient> logger)
+{
+    private readonly ILogger<BookCoverClient> _logger = logger;
+    private readonly HttpClient _client = new();
+
+    public async Task<(byte[] ImageData, string Mime)> DownloadCoverAsync(string isbn, Volume.VolumeInfoData book)
+    {
+        var openLibraryCover = await TryDownloadOpenLibraryCoverAsync(isbn);
+        if (openLibraryCover is not null)
+        {
+            return openLibraryCover.Value;
+        }
+
+        var googleBooksCover = await TryDownloadGoogleBooksCoverAsync(book);
+        if (googleBooksCover is not null)
+        {
+            return googleBooksCover.Value;
+        }
+
+        throw new Experience2NotionException("書籍の表紙画像が見つかりませんでした。");
+    }
+
+    private async Task<(byte[] ImageData, string Mime)?> TryDownloadOpenLibraryCoverAsync(string isbn)
+    {
+        var normalizedIsbn = NormalizeIsbn(isbn);
+        var url = $"https://covers.openlibrary.org/b/isbn/{normalizedIsbn}-L.jpg?default=false";
+        _logger.LogInformation("Open Library Covers APIから書籍表紙を取得します。ISBN: {Isbn}", normalizedIsbn);
+
+        using var response = await _client.GetAsync(url);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            _logger.LogInformation("Open Library Covers APIに書籍表紙が見つかりませんでした。ISBN: {Isbn}", normalizedIsbn);
+            return null;
+        }
+
+        response.EnsureSuccessStatusCode();
+        var imageData = await response.Content.ReadAsByteArrayAsync();
+        var mime = response.Content.Headers.ContentType?.MediaType ?? "image/jpeg";
+        _logger.LogInformation("Open Library Covers APIから書籍表紙を取得しました。ISBN: {Isbn}", normalizedIsbn);
+        return (imageData, mime);
+    }
+
+    private async Task<(byte[] ImageData, string Mime)?> TryDownloadGoogleBooksCoverAsync(Volume.VolumeInfoData book)
+    {
+        var url = GetGoogleBooksImageUrl(book.ImageLinks);
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            _logger.LogInformation("Google Booksに書籍表紙画像URLが見つかりませんでした。タイトル: {Title}", book.Title);
+            return null;
+        }
+
+        _logger.LogInformation("Google Booksから書籍表紙を取得します。タイトル: {Title}, URL: {Url}", book.Title, url);
+        using var response = await _client.GetAsync(url);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            _logger.LogInformation("Google Booksの書籍表紙画像が見つかりませんでした。タイトル: {Title}, URL: {Url}", book.Title, url);
+            return null;
+        }
+
+        response.EnsureSuccessStatusCode();
+        var imageData = await response.Content.ReadAsByteArrayAsync();
+        var mime = response.Content.Headers.ContentType?.MediaType ?? "image/jpeg";
+        _logger.LogInformation("Google Booksから書籍表紙を取得しました。タイトル: {Title}", book.Title);
+        return (imageData, mime);
+    }
+
+    private static string? GetGoogleBooksImageUrl(Volume.VolumeInfoData.ImageLinksData? imageLinks)
+    {
+        if (imageLinks is null)
+        {
+            return null;
+        }
+
+        return imageLinks.ExtraLarge
+            ?? imageLinks.Large
+            ?? imageLinks.Medium
+            ?? imageLinks.Small
+            ?? imageLinks.Thumbnail
+            ?? imageLinks.SmallThumbnail;
+    }
+
+    private static string NormalizeIsbn(string isbn)
+    {
+        return isbn.Replace("-", string.Empty).Replace(" ", string.Empty).Trim();
+    }
+}

--- a/Experience2Notion/Services/GoogleBookSeacher.cs
+++ b/Experience2Notion/Services/GoogleBookSeacher.cs
@@ -1,13 +1,25 @@
 ﻿using Experience2Notion.Exceptions;
 using Google.Apis.Books.v1;
 using Google.Apis.Books.v1.Data;
+using Google.Apis.Services;
 using Microsoft.Extensions.Logging;
 
 namespace Experience2Notion.Services;
-public class GoogleBookSeacher(ILogger<GoogleBookSeacher> logger)
+public class GoogleBookSeacher
 {
-    readonly ILogger<GoogleBookSeacher> _logger = logger;
-    readonly BooksService _service = new();
+    readonly ILogger<GoogleBookSeacher> _logger;
+    readonly BooksService _service;
+
+    public GoogleBookSeacher(ILogger<GoogleBookSeacher> logger)
+    {
+        _logger = logger;
+        var apiKey = Environment.GetEnvironmentVariable("GOOGLE_BOOKS_API_KEY") ?? throw new ArgumentException("Google Books APIキーが指定されていません。");
+        _service = new BooksService(new BaseClientService.Initializer
+        {
+            ApiKey = apiKey,
+            ApplicationName = "Experience2Notion"
+        });
+    }
 
     public async Task<Volume.VolumeInfoData> SearchByIsbnAsync(string isbn)
     {


### PR DESCRIPTION
## 概要

- 書籍表紙画像を取得する `BookCoverClient` を追加
- ISBN を使って Open Library Covers API の L サイズ表紙を優先取得
- Open Library に表紙が無い場合は Google Books の `ImageLinks` に fallback
- どちらからも取得できない場合は `Experience2NotionException` を投げる

## 確認

- `dotnet build Experience2Notion/Experience2Notion.csproj`
- `dotnet build Experience2Notion_App/Experience2Notion_App.csproj`

Closes #24