### PR TITLE
MusicBrainz APIを利用して音楽アルバムの情報を取得するクライアントを作成

### DIFF
--- a/Experience2Notion/Models/MusicAlbums/Album.cs
+++ b/Experience2Notion/Models/MusicAlbums/Album.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+
+namespace Experience2Notion.Models.MusicAlbums;
+
+public class Album
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("artists")]
+    public List<Artist> Artists { get; set; } = [];
+
+    [JsonPropertyName("images")]
+    public List<Image> Images { get; set; } = [];
+
+    [JsonPropertyName("release_date")]
+    public string ReleaseDate { get; set; } = string.Empty;
+
+    public string ExternalUrl { get; set; } = string.Empty;
+}

--- a/Experience2Notion/Models/MusicAlbums/Artist.cs
+++ b/Experience2Notion/Models/MusicAlbums/Artist.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace Experience2Notion.Models.MusicAlbums;
+
+public class Artist
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+}

--- a/Experience2Notion/Models/MusicAlbums/Image.cs
+++ b/Experience2Notion/Models/MusicAlbums/Image.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Experience2Notion.Models.MusicAlbums;
+
+public class Image
+{
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = string.Empty;
+
+    [JsonPropertyName("height")]
+    public int Height { get; set; }
+
+    [JsonPropertyName("width")]
+    public int Width { get; set; }
+}

--- a/Experience2Notion/Models/Spotifies/Album.cs
+++ b/Experience2Notion/Models/Spotifies/Album.cs
@@ -18,5 +18,35 @@ public class Album
     [JsonPropertyName("release_date")]
     public string ReleaseDate { get; set; } = string.Empty;
 
-    public string ExternalUrl => $"https://open.spotify.com/album/{Id}";
+    [JsonPropertyName("external_urls")]
+    public SpotifyExternalUrls ExternalUrls { get; set; } = new();
+
+    public string ExternalUrl { get; set; } = string.Empty;
+
+    public Experience2Notion.Models.MusicAlbums.Album ToAlbum()
+    {
+        return new Experience2Notion.Models.MusicAlbums.Album
+        {
+            Id = Id,
+            Name = Name,
+            Artists = Artists.Select(artist => new Experience2Notion.Models.MusicAlbums.Artist
+            {
+                Name = artist.Name,
+            }).ToList(),
+            Images = Images.Select(image => new Experience2Notion.Models.MusicAlbums.Image
+            {
+                Url = image.Url,
+                Height = image.Height,
+                Width = image.Width,
+            }).ToList(),
+            ReleaseDate = ReleaseDate,
+            ExternalUrl = string.IsNullOrWhiteSpace(ExternalUrl) ? ExternalUrls.Spotify : ExternalUrl,
+        };
+    }
+}
+
+public class SpotifyExternalUrls
+{
+    [JsonPropertyName("spotify")]
+    public string Spotify { get; set; } = string.Empty;
 }

--- a/Experience2Notion/Services/MusicAlbumSearchClient.cs
+++ b/Experience2Notion/Services/MusicAlbumSearchClient.cs
@@ -1,0 +1,234 @@
+using Experience2Notion.Models.MusicAlbums;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Experience2Notion.Services;
+
+public class MusicAlbumSearchClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly ILogger<MusicAlbumSearchClient> _logger;
+    private readonly HttpClient _client = new();
+
+    public MusicAlbumSearchClient(ILogger<MusicAlbumSearchClient> logger)
+    {
+        _logger = logger;
+        _client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Experience2Notion", "1.0"));
+    }
+
+    public async Task<Album?> SearchAlbumAsync(string albumName, string artist)
+    {
+        _logger.LogInformation("MusicBrainzから音楽アルバムを検索します。アルバム名: {AlbumName}, アーティスト: {Artist}", albumName, artist);
+
+        var searchResponse = await SearchMusicBrainzAsync(albumName, artist);
+        if (searchResponse?.Releases.Count is null or 0)
+        {
+            _logger.LogWarning("MusicBrainzにアルバムが見つかりませんでした。アルバム名: {AlbumName}, アーティスト: {Artist}", albumName, artist);
+            return null;
+        }
+
+        var release = SelectRelease(searchResponse.Releases, albumName, artist);
+        if (release is null)
+        {
+            _logger.LogWarning("MusicBrainzの検索結果から対象アルバムを選択できませんでした。アルバム名: {AlbumName}, アーティスト: {Artist}", albumName, artist);
+            return null;
+        }
+
+        var coverImageUrl = await TryGetCoverImageUrlAsync(release.Id);
+        var album = new Album
+        {
+            Id = release.Id,
+            Name = release.Title,
+            Artists = release.ArtistCredits.Select(credit => new Artist
+            {
+                Name = GetArtistName(credit),
+            }).Where(artist => !string.IsNullOrWhiteSpace(artist.Name)).ToList(),
+            Images = string.IsNullOrWhiteSpace(coverImageUrl)
+                ? []
+                : [new Image { Url = coverImageUrl }],
+            ReleaseDate = release.Date,
+            ExternalUrl = $"https://musicbrainz.org/release/{release.Id}",
+        };
+
+        _logger.LogInformation("MusicBrainzでアルバムが見つかりました。アルバム名: {AlbumName}, アーティスト: {Artist}, URL: {Url}", album.Name, string.Join(", ", album.Artists.Select(a => a.Name)), album.ExternalUrl);
+        return album;
+    }
+
+    private async Task<MusicBrainzSearchResponse?> SearchMusicBrainzAsync(string albumName, string artist)
+    {
+        var query = $"release:\"{albumName}\" AND artist:\"{artist}\"";
+        var url = $"https://musicbrainz.org/ws/2/release?query={Uri.EscapeDataString(query)}&fmt=json&limit=10";
+        using var response = await _client.GetAsync(url);
+        response.EnsureSuccessStatusCode();
+
+        using var stream = await response.Content.ReadAsStreamAsync();
+        return await JsonSerializer.DeserializeAsync<MusicBrainzSearchResponse>(stream, JsonOptions);
+    }
+
+    private static MusicBrainzRelease? SelectRelease(List<MusicBrainzRelease> releases, string albumName, string artist)
+    {
+        // MusicBrainzのアーティストクレジット名は、完全一致ランキングにおいてリリースアーティストを表すものとします
+        return releases
+            .OrderByDescending(release => IsExactArtistMatch(release, artist))
+            .ThenByDescending(release => IsExactAlbumTitleMatch(release, albumName))
+            .ThenBy(release => TryParseReleaseDate(release.Date, out var date) ? date : DateOnly.MaxValue)
+            .FirstOrDefault();
+    }
+
+    private async Task<string?> TryGetCoverImageUrlAsync(string releaseId)
+    {
+        var url = $"https://coverartarchive.org/release/{releaseId}";
+        using var response = await _client.GetAsync(url);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            _logger.LogInformation("Cover Art Archiveにカバー画像が見つかりませんでした。MusicBrainz Release ID: {ReleaseId}", releaseId);
+            return null;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("Cover Art Archiveからカバー画像を取得できませんでした。MusicBrainz Release ID: {ReleaseId}, StatusCode: {StatusCode}", releaseId, response.StatusCode);
+            return null;
+        }
+
+        using var stream = await response.Content.ReadAsStreamAsync();
+        var coverArt = await JsonSerializer.DeserializeAsync<CoverArtArchiveResponse>(stream, JsonOptions);
+        var imageUrl = GetBestCoverImageUrl(coverArt);
+        if (string.IsNullOrWhiteSpace(imageUrl))
+        {
+            _logger.LogInformation("Cover Art Archiveレスポンスに使用可能なカバー画像URLがありませんでした。MusicBrainz Release ID: {ReleaseId}", releaseId);
+            return null;
+        }
+
+        return imageUrl;
+    }
+
+    private static string? GetBestCoverImageUrl(CoverArtArchiveResponse? coverArt)
+    {
+        var image = coverArt?.Images
+            .OrderByDescending(image => image.Front)
+            .FirstOrDefault();
+
+        if (image is null)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(image.Image))
+        {
+            return image.Image;
+        }
+
+        return GetThumbnail(image.Thumbnails, "large")
+            ?? GetThumbnail(image.Thumbnails, "500")
+            ?? GetThumbnail(image.Thumbnails, "small")
+            ?? GetThumbnail(image.Thumbnails, "250");
+    }
+
+    private static string? GetThumbnail(Dictionary<string, string>? thumbnails, string key)
+    {
+        return thumbnails is not null && thumbnails.TryGetValue(key, out var url) && !string.IsNullOrWhiteSpace(url)
+            ? url
+            : null;
+    }
+
+    private static bool IsExactArtistMatch(MusicBrainzRelease release, string artist)
+    {
+        return release.ArtistCredits.Any(credit => string.Equals(Normalize(GetArtistName(credit)), Normalize(artist), StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsExactAlbumTitleMatch(MusicBrainzRelease release, string albumName)
+    {
+        return string.Equals(Normalize(release.Title), Normalize(albumName), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetArtistName(MusicBrainzArtistCredit credit)
+    {
+        return string.IsNullOrWhiteSpace(credit.Name) ? credit.Artist.Name : credit.Name;
+    }
+
+    private static string Normalize(string value)
+    {
+        return value.Trim();
+    }
+
+    private static bool TryParseReleaseDate(string value, out DateOnly date)
+    {
+        date = DateOnly.MaxValue;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var parts = value.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0 || !int.TryParse(parts[0], out var year))
+        {
+            return false;
+        }
+
+        var month = parts.Length > 1 && int.TryParse(parts[1], out var parsedMonth) ? parsedMonth : 1;
+        var day = parts.Length > 2 && int.TryParse(parts[2], out var parsedDay) ? parsedDay : 1;
+        return DateOnly.TryParse($"{year:D4}-{month:D2}-{day:D2}", out date);
+    }
+
+    private sealed class MusicBrainzSearchResponse
+    {
+        [JsonPropertyName("releases")]
+        public List<MusicBrainzRelease> Releases { get; set; } = [];
+    }
+
+    private sealed class MusicBrainzRelease
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("title")]
+        public string Title { get; set; } = string.Empty;
+
+        [JsonPropertyName("date")]
+        public string Date { get; set; } = string.Empty;
+
+        [JsonPropertyName("artist-credit")]
+        public List<MusicBrainzArtistCredit> ArtistCredits { get; set; } = [];
+    }
+
+    private sealed class MusicBrainzArtistCredit
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("artist")]
+        public MusicBrainzArtist Artist { get; set; } = new();
+    }
+
+    private sealed class MusicBrainzArtist
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class CoverArtArchiveResponse
+    {
+        [JsonPropertyName("images")]
+        public List<CoverArtImage> Images { get; set; } = [];
+    }
+
+    private sealed class CoverArtImage
+    {
+        [JsonPropertyName("image")]
+        public string Image { get; set; } = string.Empty;
+
+        [JsonPropertyName("front")]
+        public bool Front { get; set; }
+
+        [JsonPropertyName("thumbnails")]
+        public Dictionary<string, string> Thumbnails { get; set; } = [];
+    }
+}

--- a/Experience2Notion/Services/SpotifyClient.cs
+++ b/Experience2Notion/Services/SpotifyClient.cs
@@ -6,6 +6,7 @@ using System.Net.Mime;
 using System.Text;
 using System.Text.Json;
 using System.Web;
+using MusicAlbum = Experience2Notion.Models.MusicAlbums.Album;
 
 namespace Experience2Notion.Services;
 public class SpotifyClient
@@ -46,7 +47,7 @@ public class SpotifyClient
         return json.RootElement.GetProperty("access_token").GetString()!;
     }
 
-    public async Task<Album?> SearchAlbumAsync(string albumName, string artist)
+    public async Task<MusicAlbum?> SearchAlbumAsync(string albumName, string artist)
     {
         _logger.LogInformation("Spotifyから音楽アルバムを検索します。アルバム名: {AlbumName}, アーティスト: {Artist}", albumName, artist);
         if (albumName.EndsWith(_singleSuffix, StringComparison.OrdinalIgnoreCase))
@@ -69,9 +70,9 @@ public class SpotifyClient
             throw new Experience2NotionException($"アルバムが見つかりませんでした。アルバム名: {albumName}, アーティスト: {artist}");
         }
 
-        var targetAlbum = data.Albums.Items.FirstOrDefault()!;
+        var targetAlbum = data.Albums.Items.FirstOrDefault()!.ToAlbum();
         _logger.LogInformation("アルバムが見つかりました。" +
-            "アルバム名: {AlbumName}, アーティスト: {Artist}, Spotify URL: {Url}", targetAlbum.Name, string.Join(", ", targetAlbum.Artists.Select(a => a.Name)), targetAlbum.ExternalUrl);
+            "アルバム名: {AlbumName}, アーティスト: {Artist}, URL: {Url}", targetAlbum.Name, string.Join(", ", targetAlbum.Artists.Select(a => a.Name)), targetAlbum.ExternalUrl);
         return targetAlbum;
     }
 


### PR DESCRIPTION
## 対応issue
close #26 

## 実装内容
- Spotify APIが有料になったので、代わりにMusicBrainz APIを使った実装を追加した

## テスト内容
- [ ] a

## やらないこと/他issueでやること
- 

## その他レビュアーに伝えたいこと
- 
