### PR TITLE
feat: add Brave Search client (#28)

### DIFF
--- a/Experience2Notion/Models/Braves/BraveSearchResponse.cs
+++ b/Experience2Notion/Models/Braves/BraveSearchResponse.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace Experience2Notion.Models.Braves;
+
+public class BraveSearchResponse
+{
+    [JsonPropertyName("web")]
+    public BraveWebSearch? Web { get; set; }
+}
+
+public class BraveWebSearch
+{
+    [JsonPropertyName("results")]
+    public List<BraveSearchResult> Results { get; set; } = [];
+}
+
+public class BraveSearchResult
+{
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = string.Empty;
+}

--- a/Experience2Notion/Services/BraveSearchClient.cs
+++ b/Experience2Notion/Services/BraveSearchClient.cs
@@ -1,0 +1,51 @@
+using Experience2Notion.Exceptions;
+using Experience2Notion.Models.Braves;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+using System.Web;
+
+namespace Experience2Notion.Services;
+
+public class BraveSearchClient
+{
+    private readonly ILogger<BraveSearchClient> _logger;
+    private readonly HttpClient _client = new();
+
+    public BraveSearchClient(ILogger<BraveSearchClient> logger)
+    {
+        _logger = logger;
+
+        var apiKey = Environment.GetEnvironmentVariable("BRAVE_SEARCH_API_KEY")
+            ?? throw new ArgumentException("BRAVE_SEARCH_API_KEY が設定されていません。");
+
+        _client.DefaultRequestHeaders.Add("X-Subscription-Token", apiKey);
+    }
+
+    public async Task<IReadOnlyList<BraveSearchResult>> SearchAsync(string query)
+    {
+        _logger.LogInformation("Brave Searchで検索します。クエリ: {Query}", query);
+
+        var qs = HttpUtility.ParseQueryString(string.Empty);
+        qs["q"] = query;
+        qs["country"] = "JP";
+        qs["search_lang"] = "ja";
+        qs["ui_lang"] = "ja-JP";
+        qs["count"] = "10";
+
+        var url = $"https://api.search.brave.com/res/v1/web/search?{qs}";
+
+        var response = await _client.GetAsync(url);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<BraveSearchResponse>(json);
+
+        var items = result?.Web?.Results;
+        if (items is null || items.Count == 0)
+        {
+            throw new Experience2NotionException($"指定されたクエリ『{query}』の検索結果が見つかりませんでした。");
+        }
+
+        return items;
+    }
+}


### PR DESCRIPTION
## Summary

Implements Issue #28.

### Added
- BraveSearchClient
- Brave Search response models
- Environment variable support via `BRAVE_SEARCH_API_KEY`

### Behavior
- Executes web searches using Brave Search API
- Returns search results with title, url and description
- Uses Japanese search defaults
  - country=JP
  - search_lang=ja
  - ui_lang=ja-JP
- Throws Experience2NotionException when no search results are found

### Out of scope
- CreateRestaurantPageFunction migration
- Google Custom Search replacement in callers

Closes #28